### PR TITLE
Append port to the base URL if defined when generating public URLs

### DIFF
--- a/drivers/s3/driver.ts
+++ b/drivers/s3/driver.ts
@@ -411,11 +411,13 @@ export class S3Driver implements DriverContract {
      */
     if (this.#client.config.endpoint) {
       const endpoint = await this.#client.config.endpoint()
+      let baseUrl = `${endpoint.protocol}//${endpoint.hostname}`
 
-      return new URL(
-        `/${this.options.bucket}/${key}`,
-        `${endpoint.protocol}//${endpoint.hostname}`
-      ).toString()
+      if (endpoint.port) {
+        baseUrl += `:${endpoint.port}`
+      }
+
+      return new URL(`/${this.options.bucket}/${key}`, baseUrl).toString()
     }
 
     /**


### PR DESCRIPTION
Hey! :wave: 

Following a discussion with @thetutlage  on Discord and at his request, I created this PR to address an issue with the getUrl() method: if an S3 endpoint includes a port, the port is stripped when generating a public URL, resulting in an incorrect URL.

This PR fixes this behaviour by adding the port only if it's defined.

There's another problem (that should be solved in another PR: when `cdnUrl` is used, if it doesn't have a trailing slash, the pathname will be removed and the bucket used will not be included in the public URL generated by the getUrl() method. The following is an example for the same:

```
# In .env

S3_ENDPOINT=http://localhost:9000
S3_BUCKET=local
```


```ts
// In config/drive.ts

{
  s3: services.s3({
    cdnUrl: `${env.get('S3_ENDPOINT')}/${env.get('S3_BUCKET')}`,
  }),
}
```

In this case, using `await drive.use().getUrl('foo/bar.png')` will result in the following generated URL: `http://localhost:9000/foo/bar.png` which is wrong. The correct URL should be: `http://localhost:9000/local/foo/bar.png`.

To address this issue, we can either add a trailing slash automatically to cdnUrl, or let devs do it manually, i.e :

```ts
// In config/drive.ts configuration

{
  s3: services.s3({
    cdnUrl: `${env.get('S3_ENDPOINT')}/${env.get('S3_BUCKET')}/`,
    //                                                        ^----- Here
}
```

I can work on the second issue too, if necessary.

Thank you!
