### PR TITLE
feat: add encryption option to S3

### DIFF
--- a/drivers/s3/driver.ts
+++ b/drivers/s3/driver.ts
@@ -114,6 +114,7 @@ export class S3Driver implements DriverContract {
      */
     const s3Options: Omit<PutObjectCommandInput, 'Key'> = {
       Bucket: this.options.bucket,
+      ServerSideEncryption: this.options.encryption,
       ...rest,
     }
 

--- a/drivers/s3/types.ts
+++ b/drivers/s3/types.ts
@@ -7,7 +7,12 @@
  * file that was distributed with this source code.
  */
 
-import type { GetObjectAclCommandInput, S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
+import type {
+  GetObjectAclCommandInput,
+  S3Client,
+  S3ClientConfig,
+  ServerSideEncryption,
+} from '@aws-sdk/client-s3'
 import type { ObjectVisibility } from '../../src/types.js'
 
 /**
@@ -61,6 +66,11 @@ type S3DriverBaseOptions = {
       client: S3Client
     ): Promise<string>
   }
+
+  /**
+   * Encryption to use when uploading files to S3.
+   */
+  encryption?: ServerSideEncryption
 }
 
 /**


### PR DESCRIPTION
We use S3 bucket policy to only allow uploads with ServerSideEncryption set. Currently we have to provide the `ServerSideEncryption` option with every request to save a file. This PR allows to set encryption in config globally and pass it to save save options when uploading a file.

Example policy:
```
{
    "Version": "2012-10-17",
    "Id": "PutObjectPolicy",
    "Statement": [
        {
            "Sid": "DenyObjectsThatAreNotSSES3",
            "Effect": "Deny",
            "Principal": "*",
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::bucket-name/*",
            "Condition": {
                "StringNotEquals": {
                    "s3:x-amz-server-side-encryption": "AES256"
                }
            }
        }
    ]
}
```