### PR TITLE
feat: add signed url uploads with some initial tests

### DIFF
--- a/drivers/fs/driver.ts
+++ b/drivers/fs/driver.ts
@@ -224,6 +224,29 @@ export class FSDriver implements DriverContract {
     throw new RuntimeException('Cannot generate signed URL. The "fs" driver does not support it')
   }
 
+  async getSignedUploadUrl(key: string, options?: SignedURLOptions): Promise<string> {
+    const location = join(this.#rootUrl, key)
+    const normalizedOptions = Object.assign(
+      {
+        expiresIn: '30 mins',
+      },
+      options
+    )
+
+    /**
+     * Use custom implementation when exists.
+     */
+    const generateSignedUploadURL = this.options.urlBuilder?.generateSignedUploadURL
+    if (generateSignedUploadURL) {
+      debug('generating signed upload URL %s:%s', this.#rootUrl, key)
+      return generateSignedUploadURL(key, location, normalizedOptions)
+    }
+
+    throw new RuntimeException(
+      'Cannot generate signed upload URL. The "fs" driver does not support it'
+    )
+  }
+
   /**
    * Results in noop, since the local filesystem cannot have per
    * object visibility.

--- a/drivers/fs/types.ts
+++ b/drivers/fs/types.ts
@@ -41,5 +41,14 @@ export type FSDriverOptions = {
      * Custom implementation for creating signed/temporary URLs
      */
     generateSignedURL?(key: string, filePath: string, options: SignedURLOptions): Promise<string>
+
+    /**
+     * Custom implementation for creating signed/temporary URLs for uploading files
+     */
+    generateSignedUploadURL?(
+      key: string,
+      filePath: string,
+      options: SignedURLOptions
+    ): Promise<string>
   }
 }

--- a/drivers/gcs/driver.ts
+++ b/drivers/gcs/driver.ts
@@ -280,6 +280,49 @@ export class GCSDriver implements DriverContract {
   }
 
   /**
+   * Returns the signed/temporary URL that can be used to directly upload
+   * the file contents to the storage. By default, the signed URLs
+   * expire in 30mins, but a custom expiry can be defined using
+   * "options.expiresIn" property.
+   */
+  async getSignedUploadUrl(key: string, options?: SignedURLOptions): Promise<string> {
+    const { contentDisposition, contentType, expiresIn, ...rest } = Object.assign({}, options)
+
+    /**
+     * Options passed to GCS when generating the signed URL.
+     */
+    const expires = new Date()
+    expires.setSeconds(new Date().getSeconds() + string.seconds.parse(expiresIn || '30mins'))
+
+    const signedURLOptions: GetSignedUrlConfig = {
+      action: 'write',
+      expires: expires,
+      contentType,
+      ...rest,
+    }
+
+    /**
+     * Use custom implementation when exists.
+     */
+    const generateSignedUploadURL = this.options.urlBuilder?.generateSignedUploadURL
+    if (generateSignedUploadURL) {
+      debug(
+        'using custom implementation for generating signed upload URL %s:%s',
+        this.options.bucket,
+        key
+      )
+      return generateSignedUploadURL(key, this.options.bucket, signedURLOptions, this.#storage)
+    }
+
+    debug('generating signed URL %s:%s', this.options.bucket, key)
+    const bucket = this.#storage.bucket(this.options.bucket)
+    const file = bucket.file(key)
+
+    const response = await file.getSignedUrl(signedURLOptions)
+    return response[0]
+  }
+
+  /**
    * Updates the visibility of a file
    */
   async setVisibility(key: string, visibility: ObjectVisibility): Promise<void> {

--- a/drivers/gcs/types.ts
+++ b/drivers/gcs/types.ts
@@ -54,6 +54,16 @@ type GCSDriverBaseOptions = {
       config: GetSignedUrlConfig,
       storage: Storage
     ): Promise<string>
+
+    /**
+     * Custom implementation for creating signed/temporary URLs for uploading files
+     */
+    generateSignedUploadURL?(
+      key: string,
+      bucket: string,
+      config: GetSignedUrlConfig,
+      storage: Storage
+    ): Promise<string>
   }
 }
 

--- a/drivers/s3/driver.ts
+++ b/drivers/s3/driver.ts
@@ -458,11 +458,52 @@ export class S3Driver implements DriverContract {
     const generateSignedURL = this.options.urlBuilder?.generateSignedURL
     if (generateSignedURL) {
       debug('using custom implementation for generating signed URL %s:%s', this.options.bucket, key)
-      return generateSignedURL(key, signedURLOptions, this.#client)
+      return generateSignedURL(key, signedURLOptions, this.#client, expiresIn)
     }
 
     debug('generating signed URL %s:%s', this.options.bucket, key)
     return getSignedUrl(this.#client, this.createGetObjectCommand(this.#client, signedURLOptions), {
+      expiresIn: expires,
+    })
+  }
+
+  /**
+   * Returns a signed URL for uploading objects directly to S3.
+   */
+  async getSignedUploadUrl(key: string, options?: SignedURLOptions): Promise<string> {
+    const { contentType, expiresIn, ...rest } = Object.assign({}, options)
+
+    /**
+     * Options passed to GCS when generating the signed URL.
+     */
+    const expires = string.seconds.parse(expiresIn || '30mins')
+
+    /**
+     * Options given to the PutObjectCommand when create a signed
+     * URL
+     */
+    const signedURLOptions: PutObjectCommandInput = {
+      Key: key,
+      Bucket: this.options.bucket,
+      ContentType: contentType,
+      ...rest,
+    }
+
+    /**
+     * Use custom implementation when exists.
+     */
+    const generateSignedUploadURL = this.options.urlBuilder?.generateSignedUploadURL
+    if (generateSignedUploadURL) {
+      debug(
+        'using custom implementation for generating signed upload URL %s:%s',
+        this.options.bucket,
+        key
+      )
+      return generateSignedUploadURL(key, signedURLOptions, this.#client, expiresIn)
+    }
+
+    debug('generating signed upload URL %s:%s', this.options.bucket, key)
+    return getSignedUrl(this.#client, this.createPutObjectCommand(this.#client, signedURLOptions), {
       expiresIn: expires,
     })
   }

--- a/drivers/s3/types.ts
+++ b/drivers/s3/types.ts
@@ -9,6 +9,7 @@
 
 import type {
   GetObjectAclCommandInput,
+  PutObjectCommandInput,
   S3Client,
   S3ClientConfig,
   ServerSideEncryption,
@@ -63,7 +64,18 @@ type S3DriverBaseOptions = {
     generateSignedURL?(
       key: string,
       options: GetObjectAclCommandInput,
-      client: S3Client
+      client: S3Client,
+      expiresIn?: number | string
+    ): Promise<string>
+
+    /**
+     * Custom implementation for creating signed/temporary URLs for uploading files
+     */
+    generateSignedUploadURL?(
+      key: string,
+      options: PutObjectCommandInput,
+      client: S3Client,
+      expiresIn?: number | string
     ): Promise<string>
   }
 

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -123,6 +123,14 @@ export class Disk {
   }
 
   /**
+   * Returns a signed/temporary URL that can be used to directly upload
+   * the file contents to the storage.
+   */
+  getSignedUploadUrl(key: string, options?: SignedURLOptions): Promise<string> {
+    return this.file(key).getSignedUploadUrl(options)
+  }
+
+  /**
    * Update the visibility of the file
    */
   async setVisibility(key: string, visibility: ObjectVisibility): Promise<void> {

--- a/src/driver_file.ts
+++ b/src/driver_file.ts
@@ -172,6 +172,18 @@ export class DriveFile {
   }
 
   /**
+   * Returns a signed/temporary URL that can be used to directly upload
+   * the file contents to the storage.
+   */
+  async getSignedUploadUrl(options?: SignedURLOptions) {
+    try {
+      return await this.#driver.getSignedUploadUrl(this.key, options)
+    } catch (error) {
+      throw new errors.E_CANNOT_GENERATE_URL([this.key], { cause: error })
+    }
+  }
+
+  /**
    * Returns a snapshot of the file. The snapshot could be persisted
    * within any database storage and later you can create a file
    * instance from it using the "disk.fromSnapshot" method.

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,12 @@ export interface DriverContract {
   getSignedUrl(key: string, options?: SignedURLOptions): Promise<string>
 
   /**
+   * Return the signed/temporary URL that can be used to directly upload
+   * the file contents to the storage.
+   */
+  getSignedUploadUrl(key: string, options?: SignedURLOptions): Promise<string>
+
+  /**
    * Update the visibility of the file
    */
   setVisibility(key: string, visibility: ObjectVisibility): Promise<void>

--- a/tests/core/disk.spec.ts
+++ b/tests/core/disk.spec.ts
@@ -317,6 +317,52 @@ test.group('Disk | getSignedUrl', () => {
   })
 })
 
+test.group('Disk | getSignedUploadUrl', () => {
+  test('get file upload url from the underlying driver', async ({ fs, assert }) => {
+    const key = 'hello.txt'
+    const contents = 'Hello world'
+
+    const fdfs = new FSDriver({
+      location: fs.baseUrl,
+      visibility: 'public',
+      urlBuilder: {
+        async generateSignedUploadURL(fileKey) {
+          return `/assets/${fileKey}`
+        },
+      },
+    })
+    await fdfs.put(key, contents)
+
+    const disk = new Disk(fdfs)
+    assert.equal(await disk.getSignedUploadUrl(key), '/assets/hello.txt')
+  })
+
+  test('wrap driver errors into generic error', async ({ fs, assert }) => {
+    assert.plan(3)
+    const key = 'hello.txt'
+    const contents = 'Hello world'
+
+    const fdfs = new FSDriver({
+      location: fs.baseUrl,
+      visibility: 'public',
+    })
+    await fdfs.put(key, contents)
+
+    const disk = new Disk(fdfs)
+
+    try {
+      await disk.getSignedUploadUrl(key)
+    } catch (error) {
+      assert.instanceOf(error, errors.E_CANNOT_GENERATE_URL)
+      assert.equal(error.message, 'Cannot generate URL for file at location "hello.txt"')
+      assert.equal(
+        error.cause.message,
+        'Cannot generate signed URL. The "fs" driver does not support it'
+      )
+    }
+  })
+})
+
 test.group('Disk | put', () => {
   test('create a new file', async ({ fs, assert }) => {
     const key = 'hello.txt'

--- a/tests/drivers/fs/url_generation.spec.ts
+++ b/tests/drivers/fs/url_generation.spec.ts
@@ -62,4 +62,30 @@ test.group('FS Driver | getUrl', () => {
 
     assert.equal(await fdfs.getSignedUrl(key), '/assets/hello.txt?signature=foo')
   })
+
+  test('throw error when trying to generate a signed upload URL', async ({ fs, assert }) => {
+    const key = 'hello.txt'
+
+    const fdfs = new FSDriver({ location: fs.baseUrl, visibility: 'public' })
+    await assert.rejects(
+      () => fdfs.getSignedUploadUrl(key),
+      'Cannot generate signed upload URL. The "fs" driver does not support it'
+    )
+  })
+
+  test('use custom implementation to generate a signed upload URL', async ({ fs, assert }) => {
+    const key = 'hello.txt'
+
+    const fdfs = new FSDriver({
+      location: fs.baseUrl,
+      visibility: 'public',
+      urlBuilder: {
+        async generateSignedUploadURL(fileKey) {
+          return `/assets/${fileKey}?signature=foo`
+        },
+      },
+    })
+
+    assert.equal(await fdfs.getSignedUploadUrl(key), '/assets/hello.txt?signature=foo')
+  })
 })

--- a/tests/drivers/gcs/url_generation.spec.ts
+++ b/tests/drivers/gcs/url_generation.spec.ts
@@ -167,3 +167,98 @@ test.group('GCS Driver | getSignedUrl', (group) => {
     assert.equal(fileURL.host, 'cdn.example.com')
   })
 })
+
+test.group('GCS Driver | getSignedUploadUrl', (group) => {
+  group.each.setup(() => {
+    return async () => {
+      await bucket.deleteFiles()
+      await noUniformedAclBucket.deleteFiles()
+    }
+  })
+  group.each.timeout(10_000)
+
+  test('get signed upload URL of a file', async ({ assert }) => {
+    const key = `${string.random(6)}.txt`
+
+    const fdgcs = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+
+    const fileURL = new URL(await fdgcs.getSignedUploadUrl(key))
+    await got.put(fileURL, { body: 'hello world', headers: { 'Content-Type': 'text/plain' } })
+    const fileContents = await got.get(fileURL)
+
+    assert.equal(fileURL.pathname, `/${GCS_BUCKET}/${key}`)
+    assert.isTrue(fileURL.searchParams.has('Signature'))
+    assert.isTrue(fileURL.searchParams.has('Expires'))
+
+    assert.equal(fileContents.body, 'hello world')
+  })
+
+  test('define content type for the file', async ({ assert }) => {
+    const key = `${string.random(6)}.txt`
+
+    const fdgcs = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+
+    const fileURL = new URL(
+      await fdgcs.getSignedUploadUrl(key, {
+        contentType: 'image/png',
+      })
+    )
+
+    assert.equal(fileURL.searchParams.get('response-content-type'), 'image/png')
+  })
+
+  test('define content disposition for the file', async ({ assert }) => {
+    const key = `${string.random(6)}.txt`
+
+    const fdgcs = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+
+    const fileURL = new URL(
+      await fdgcs.getSignedUploadUrl(key, {
+        contentDisposition: 'attachment',
+      })
+    )
+
+    assert.equal(fileURL.searchParams.get('response-content-disposition'), 'attachment')
+  })
+
+  test('use custom implementation for generating signed upload URL', async ({ assert }) => {
+    const key = `${string.random(6)}.txt`
+
+    const fdgcs = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+      urlBuilder: {
+        async generateSignedUploadURL(fileKey, fileBucket, options, storage) {
+          const response = await storage
+            .bucket(fileBucket)
+            .file(fileKey)
+            .getSignedUrl({
+              ...options,
+              cname: 'https://cdn.example.com',
+            })
+          return response[0]
+        },
+      },
+    })
+
+    const fileURL = new URL(await fdgcs.getSignedUploadUrl(key))
+    assert.equal(fileURL.host, 'cdn.example.com')
+  })
+})

--- a/tests/drivers/s3/url_generation.spec.ts
+++ b/tests/drivers/s3/url_generation.spec.ts
@@ -10,7 +10,7 @@
 import got from 'got'
 import { test } from '@japa/runner'
 import string from '@poppinss/utils/string'
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 
 import { S3Driver } from '../../../drivers/s3/driver.js'
 import {
@@ -213,7 +213,7 @@ test.group('S3 Driver | getSignedUploadUrl', (group) => {
   })
   group.each.timeout(10_000)
 
-  test('get signed URL of a file', async ({ assert }) => {
+  test('get signed upload URL of a file', async ({ assert }) => {
     const key = `${string.random(6)}.txt`
 
     const s3fs = new S3Driver({
@@ -267,7 +267,7 @@ test.group('S3 Driver | getSignedUploadUrl', (group) => {
     })
 
     const fileURL = new URL(
-      await s3fs.getSignedUrl(key, {
+      await s3fs.getSignedUploadUrl(key, {
         contentDisposition: 'attachment',
       })
     )
@@ -287,9 +287,9 @@ test.group('S3 Driver | getSignedUploadUrl', (group) => {
         async generateSignedUploadURL(_, options, s3Client) {
           return getSignedUrl(
             s3Client,
-            new GetObjectCommand({
+            new PutObjectCommand({
               ...options,
-              ResponseCacheControl: 'no-cache',
+              CacheControl: 'no-cache',
             })
           )
         },
@@ -297,6 +297,6 @@ test.group('S3 Driver | getSignedUploadUrl', (group) => {
     })
 
     const fileURL = new URL(await s3fs.getSignedUploadUrl(key))
-    assert.equal(fileURL.searchParams.get('response-cache-control'), 'no-cache')
+    assert.equal(fileURL.searchParams.get('cache-control'), 'no-cache')
   })
 })

--- a/tests/drivers/s3/url_generation.spec.ts
+++ b/tests/drivers/s3/url_generation.spec.ts
@@ -204,3 +204,99 @@ test.group('S3 Driver | getSignedUrl', (group) => {
     assert.equal(fileURL.searchParams.get('response-cache-control'), 'no-cache')
   })
 })
+
+test.group('S3 Driver | getSignedUploadUrl', (group) => {
+  group.each.setup(() => {
+    return async () => {
+      await deleteS3Objects(client, S3_BUCKET, '/')
+    }
+  })
+  group.each.timeout(10_000)
+
+  test('get signed URL of a file', async ({ assert }) => {
+    const key = `${string.random(6)}.txt`
+
+    const s3fs = new S3Driver({
+      visibility: 'private',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+    })
+
+    // await s3fs.put(key, 'hello world')
+
+    const fileURL = new URL(await s3fs.getSignedUploadUrl(key))
+    await got.put(fileURL, { body: 'hello world', headers: { 'Content-Type': 'text/plain' } })
+    const fileContents = await got.get(fileURL)
+
+    assert.include(fileURL.hostname, S3_BUCKET)
+    assert.equal(fileURL.pathname, `/${key}`)
+    assert.isTrue(fileURL.searchParams.has('X-Amz-Signature'))
+    assert.isTrue(fileURL.searchParams.has('X-Amz-Expires'))
+
+    assert.equal(fileContents.body, 'hello world')
+  })
+
+  test('define content type for the file', async ({ assert }) => {
+    const key = `${string.random(6)}.txt`
+
+    const s3fs = new S3Driver({
+      visibility: 'public',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+    })
+
+    const fileURL = new URL(
+      await s3fs.getSignedUploadUrl(key, {
+        contentType: 'image/png',
+      })
+    )
+
+    assert.equal(fileURL.searchParams.get('response-content-type'), 'image/png')
+  })
+
+  test('define content disposition for the file', async ({ assert }) => {
+    const key = `${string.random(6)}.txt`
+
+    const s3fs = new S3Driver({
+      visibility: 'public',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+    })
+
+    const fileURL = new URL(
+      await s3fs.getSignedUrl(key, {
+        contentDisposition: 'attachment',
+      })
+    )
+
+    assert.equal(fileURL.searchParams.get('response-content-disposition'), 'attachment')
+  })
+
+  test('use custom implementation for generating signed upload URL', async ({ assert }) => {
+    const key = `${string.random(6)}.txt`
+
+    const s3fs = new S3Driver({
+      visibility: 'public',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+      urlBuilder: {
+        async generateSignedUploadURL(_, options, s3Client) {
+          return getSignedUrl(
+            s3Client,
+            new GetObjectCommand({
+              ...options,
+              ResponseCacheControl: 'no-cache',
+            })
+          )
+        },
+      },
+    })
+
+    const fileURL = new URL(await s3fs.getSignedUploadUrl(key))
+    assert.equal(fileURL.searchParams.get('response-cache-control'), 'no-cache')
+  })
+})


### PR DESCRIPTION
Hi,

Since we desperately need #8 I've taken a stab at it. I know somebody already attempted it in #3 but we are a year later so lets try  this again. I've mainly looked at how `getSignedUrl` was implemented and applied it to all supported drivers

