### PR TITLE
feat: switch bucket at runtime

### DIFF
--- a/drivers/fs/driver.ts
+++ b/drivers/fs/driver.ts
@@ -410,4 +410,11 @@ export class FSDriver implements DriverContract {
       },
     }
   }
+
+  /**
+   * Switch bucket at runtime if supported.
+   */
+  bucket(_bucket: string): FSDriver {
+    throw new RuntimeException('Cannot switch bucket. The "fs" driver does not support it.')
+  }
 }

--- a/drivers/gcs/driver.ts
+++ b/drivers/gcs/driver.ts
@@ -509,4 +509,11 @@ export class GCSDriver implements DriverContract {
       },
     }
   }
+
+  /**
+   * Switch bucket at runtime if supported.
+   */
+  bucket(bucket: string): GCSDriver {
+    return new GCSDriver({ ...this.options, bucket })
+  }
 }

--- a/drivers/s3/driver.ts
+++ b/drivers/s3/driver.ts
@@ -713,4 +713,11 @@ export class S3Driver implements DriverContract {
       },
     }
   }
+
+  /**
+   * Switch bucket at runtime if supported.
+   */
+  bucket(bucket: string): S3Driver {
+    return new S3Driver({ ...this.options, bucket })
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,11 @@ export interface DriverContract {
     paginationToken?: string
     objects: Iterable<DriveFile | DriveDirectory>
   }>
+
+  /**
+   * Switch bucket at runtime if supported.
+   */
+  bucket(bucket: string): DriverContract
 }
 
 /**

--- a/tests/drivers/fs/bucket.spec.ts
+++ b/tests/drivers/fs/bucket.spec.ts
@@ -1,0 +1,20 @@
+/*
+ * flydrive
+ *
+ * (c) FlyDrive
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { FSDriver } from '../../../drivers/fs/driver.js'
+
+test.group('FS Driver | bucket', () => {
+  test('not supported', async ({ fs, assert }) => {
+    const fdfs = new FSDriver({ location: fs.baseUrl, visibility: 'public' })
+    assert.throws(() => {
+      fdfs.bucket('test-bucket')
+    }, 'Cannot switch bucket. The "fs" driver does not support it.')
+  })
+})

--- a/tests/drivers/gcs/bucket.spec.ts
+++ b/tests/drivers/gcs/bucket.spec.ts
@@ -1,0 +1,26 @@
+/*
+ * flydrive
+ *
+ * (c) FlyDrive
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { GCS_BUCKET, GCS_KEY } from './env.js'
+import { GCSDriver } from '../../../drivers/gcs/driver.js'
+
+test.group('GCS Driver | bucket', () => {
+  test('switch bucket', async ({ assert }) => {
+    const fdgcs = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+    assert.doesNotThrow(() => {
+      fdgcs.bucket('other-bucket')
+    })
+  })
+})

--- a/tests/drivers/s3/bucket.spec.ts
+++ b/tests/drivers/s3/bucket.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * flydrive
+ *
+ * (c) FlyDrive
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { S3Driver } from '../../../drivers/s3/driver.js'
+import {
+  AWS_ACCESS_KEY,
+  AWS_ACCESS_SECRET,
+  S3_BUCKET,
+  S3_ENDPOINT,
+  S3_REGION,
+  SUPPORTS_ACL,
+} from './env.js'
+import { S3Client } from '@aws-sdk/client-s3'
+
+/**
+ * Direct access to S3 client via their SDK
+ */
+const client = new S3Client({
+  credentials: {
+    accessKeyId: AWS_ACCESS_KEY,
+    secretAccessKey: AWS_ACCESS_SECRET,
+  },
+  endpoint: S3_ENDPOINT,
+  region: S3_REGION,
+})
+test.group('S3 Driver | bucket', () => {
+  test('switch bucket', async ({ assert }) => {
+    const s3fs = new S3Driver({
+      visibility: 'public',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+    })
+    assert.doesNotThrow(() => {
+      s3fs.bucket('other-bucket')
+    })
+  })
+})


### PR DESCRIPTION
Bring back the switch bucket at runtime feature from Adonis 5: https://v5-docs.adonisjs.com/guides/drive#switching-bucket-at-runtime

I couldn't run GCS tests as I don't have a GCP account, let me know if there is a problem with it.
Not really sure if tests are enough, again, let me know if it could be better.

Thanks for the review!