### PR TITLE
Fix missing contentLength in S3 driver listAll by mapping from Size

### DIFF
--- a/drivers/s3/driver.ts
+++ b/drivers/s3/driver.ts
@@ -31,6 +31,7 @@ import {
   type DeleteObjectCommandInput,
   type ListObjectsV2CommandInput,
   type DeleteObjectsCommandInput,
+  type _Object,
 } from '@aws-sdk/client-s3'
 
 import debug from './debug.js'
@@ -82,7 +83,7 @@ export class S3Driver implements DriverContract {
   #createFileMetaData(apiFile: HeadObjectOutput) {
     const metaData: ObjectMetaData = {
       contentType: apiFile.ContentType,
-      contentLength: apiFile.ContentLength!,
+      contentLength: apiFile.ContentLength ?? (apiFile as _Object).Size ?? 0,
       etag: apiFile.ETag!,
       lastModified: new Date(apiFile.LastModified!),
     }

--- a/tests/drivers/s3/list_all.spec.ts
+++ b/tests/drivers/s3/list_all.spec.ts
@@ -99,6 +99,14 @@ test.group('S3 Driver | listAll | root dir', (group) => {
     }
 
     const { objects } = await s3fs.listAll('/', { recursive: true })
+
+    for (const object of objects) {
+      if (object.isFile) {
+        const metadata = await object.getMetaData()
+        assert.equal(metadata.contentLength, 11)
+      }
+    }
+
     assert.includeDeepMembers(Array.from(objects), [
       {
         isDirectory: false,


### PR DESCRIPTION
## Summary
Fix an issue where `contentLength` was missing in the S3 driver `listAll` method.

According to the AWS SDK documentation, `ListObjectsV2Command` returns objects of type `_Object`, which do not include a `ContentLength` field. Instead, the object size is provided through the `Size` property.

Because of this, the `contentLength` field was not being populated correctly.

## Changes
- Map `Size` from the `ListObjectsV2Command` response to `contentLength` in the S3 driver `#createFileMetaData` method.

## Reference
AWS SDK documentation:
https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/ListObjectsV2Command/

`_Object` structure returned in `Contents`:
- `Size` → object size in bytes
- `ContentLength` is **not included** in this response

## Impact
Ensures `contentLength` is correctly returned when listing objects from S3 using the `listAll` method.