### PR TITLE
feat: support cross-bucket copy and move operations

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,6 +69,7 @@ jobs:
         env:
           GCS_KEY: ${{ secrets.GCS_KEY }}
           GCS_BUCKET: drive-gcs
+          GCS_OTHER_BUCKET: flydrive-other-bucket
           GCS_FINE_GRAINED_ACL_BUCKET: drive-gcs-no-uniform-acl
   tests-s3:
     runs-on: ${{ matrix.os }}
@@ -93,6 +94,7 @@ jobs:
         env:
           S3_SERVICE: do
           S3_BUCKET: testing-flydrive
+          S3_OTHER_BUCKET: drive-other-bucket
           S3_ACCESS_KEY: ${{ secrets.DO_ACCESS_KEY }}
           S3_ACCESS_SECRET: ${{ secrets.DO_ACCESS_SECRET }}
           S3_ENDPOINT: https://sgp1.digitaloceanspaces.com
@@ -121,6 +123,7 @@ jobs:
         env:
           S3_SERVICE: r2
           S3_BUCKET: testing-flydrive
+          S3_OTHER_BUCKET: flydrive-other-bucket
           S3_ACCESS_KEY: ${{ secrets.R2_ACCESS_KEY }}
           S3_ACCESS_SECRET: ${{ secrets.R2_ACCESS_SECRET }}
           S3_ENDPOINT: https://b7d56a259a224b185a70dd6e6f77d9c3.r2.cloudflarestorage.com

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,6 +45,7 @@ jobs:
         env:
           GCS_KEY: ${{ secrets.GCS_KEY }}
           GCS_BUCKET: drive-gcs
+          GCS_OTHER_BUCKET: flydrive-other-bucket
           GCS_FINE_GRAINED_ACL_BUCKET: drive-gcs-no-uniform-acl
   tests-gcs:
     runs-on: ${{ matrix.os }}

--- a/drivers/gcs/driver.ts
+++ b/drivers/gcs/driver.ts
@@ -383,10 +383,10 @@ export class GCSDriver implements DriverContract {
    * Copies the source file to the destination. Both paths must
    * be within the root location.
    *
-   * Use the "bucket" option to copy the file to a different bucket.
+   * Use the "destinationBucket" option to copy the file to a different bucket.
    */
   async copy(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
-    const { bucket: destinationBucket, ...writeOptions } = options || {}
+    const { destinationBucket, ...writeOptions } = options || {}
     const targetBucket = destinationBucket || this.options.bucket
 
     debug(
@@ -420,10 +420,10 @@ export class GCSDriver implements DriverContract {
    * Moves the source file to the destination. Both paths must
    * be within the root location.
    *
-   * Use the "bucket" option to move the file to a different bucket.
+   * Use the "destinationBucket" option to move the file to a different bucket.
    */
   async move(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
-    const { bucket: destinationBucket, ...writeOptions } = options || {}
+    const { destinationBucket, ...writeOptions } = options || {}
     const targetBucket = destinationBucket || this.options.bucket
 
     debug('moving file from %s:%s to %s:%s', this.options.bucket, source, targetBucket, destination)

--- a/drivers/gcs/driver.ts
+++ b/drivers/gcs/driver.ts
@@ -23,6 +23,7 @@ import { DriveFile } from '../../src/driver_file.js'
 import { DriveDirectory } from '../../src/drive_directory.js'
 import type {
   WriteOptions,
+  CopyMoveOptions,
   ObjectMetaData,
   DriverContract,
   SignedURLOptions,
@@ -381,58 +382,69 @@ export class GCSDriver implements DriverContract {
   /**
    * Copies the source file to the destination. Both paths must
    * be within the root location.
+   *
+   * Use the "bucket" option to copy the file to a different bucket.
    */
-  async copy(source: string, destination: string, options?: WriteOptions): Promise<void> {
+  async copy(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
+    const { bucket: destinationBucket, ...writeOptions } = options || {}
+    const targetBucket = destinationBucket || this.options.bucket
+
     debug(
       'copying file from %s:%s to %s:%s',
       this.options.bucket,
       source,
-      this.options.bucket,
+      targetBucket,
       destination
     )
-    const bucket = this.#storage.bucket(this.options.bucket)
-    options = options || {}
+
+    const sourceBucket = this.#storage.bucket(this.options.bucket)
 
     /**
      * Copy visibility from the source file to the
      * desintation when no inline visibility is
      * defined and not using usingUniformAcl
      */
-    if (!options.visibility && !this.#usingUniformAcl) {
-      const [isFilePublic] = await bucket.file(source).isPublic()
-      options.visibility = isFilePublic ? 'public' : 'private'
+    if (!writeOptions.visibility && !this.#usingUniformAcl) {
+      const [isFilePublic] = await sourceBucket.file(source).isPublic()
+      writeOptions.visibility = isFilePublic ? 'public' : 'private'
     }
 
-    await bucket.file(source).copy(destination, this.#getSaveOptions(options))
+    const target = destinationBucket
+      ? this.#storage.bucket(destinationBucket).file(destination)
+      : destination
+
+    await sourceBucket.file(source).copy(target, this.#getSaveOptions(writeOptions))
   }
 
   /**
    * Moves the source file to the destination. Both paths must
    * be within the root location.
+   *
+   * Use the "bucket" option to move the file to a different bucket.
    */
-  async move(source: string, destination: string, options?: WriteOptions): Promise<void> {
-    debug(
-      'moving file from %s:%s to %s:%s',
-      this.options.bucket,
-      source,
-      this.options.bucket,
-      destination
-    )
+  async move(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
+    const { bucket: destinationBucket, ...writeOptions } = options || {}
+    const targetBucket = destinationBucket || this.options.bucket
 
-    const bucket = this.#storage.bucket(this.options.bucket)
-    options = options || {}
+    debug('moving file from %s:%s to %s:%s', this.options.bucket, source, targetBucket, destination)
+
+    const sourceBucket = this.#storage.bucket(this.options.bucket)
 
     /**
      * Copy visibility from the source file to the
      * desintation when no inline visibility is
      * defined and not using usingUniformAcl
      */
-    if (!options.visibility && !this.#usingUniformAcl) {
-      const [isFilePublic] = await bucket.file(source).isPublic()
-      options.visibility = isFilePublic ? 'public' : 'private'
+    if (!writeOptions.visibility && !this.#usingUniformAcl) {
+      const [isFilePublic] = await sourceBucket.file(source).isPublic()
+      writeOptions.visibility = isFilePublic ? 'public' : 'private'
     }
 
-    await bucket.file(source).move(destination, this.#getSaveOptions(options))
+    const target = destinationBucket
+      ? this.#storage.bucket(destinationBucket).file(destination)
+      : destination
+
+    await sourceBucket.file(source).move(target, this.#getSaveOptions(writeOptions))
   }
 
   /**

--- a/drivers/s3/driver.ts
+++ b/drivers/s3/driver.ts
@@ -585,10 +585,10 @@ export class S3Driver implements DriverContract {
    * Copies the source file to the destination. Both paths must
    * be within the root location.
    *
-   * Use the "bucket" option to copy the file to a different bucket.
+   * Use the "destinationBucket" option to copy the file to a different bucket.
    */
   async copy(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
-    const { bucket: destinationBucket, ...writeOptions } = options || {}
+    const { destinationBucket, ...writeOptions } = options || {}
     const targetBucket = destinationBucket || this.options.bucket
 
     debug(
@@ -622,10 +622,10 @@ export class S3Driver implements DriverContract {
    * Moves the source file to the destination. Both paths must
    * be within the root location.
    *
-   * Use the "bucket" option to move the file to a different bucket.
+   * Use the "destinationBucket" option to move the file to a different bucket.
    */
   async move(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
-    const targetBucket = options?.bucket || this.options.bucket
+    const targetBucket = options?.destinationBucket || this.options.bucket
 
     debug('moving file from %s:%s to %s:%s', this.options.bucket, source, targetBucket, destination)
 

--- a/drivers/s3/driver.ts
+++ b/drivers/s3/driver.ts
@@ -39,6 +39,7 @@ import { DriveFile } from '../../src/driver_file.js'
 import { DriveDirectory } from '../../src/drive_directory.js'
 import type {
   WriteOptions,
+  CopyMoveOptions,
   DriverContract,
   ObjectMetaData,
   ObjectVisibility,
@@ -583,33 +584,36 @@ export class S3Driver implements DriverContract {
   /**
    * Copies the source file to the destination. Both paths must
    * be within the root location.
+   *
+   * Use the "bucket" option to copy the file to a different bucket.
    */
-  async copy(source: string, destination: string, options?: WriteOptions): Promise<void> {
+  async copy(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
+    const { bucket: destinationBucket, ...writeOptions } = options || {}
+    const targetBucket = destinationBucket || this.options.bucket
+
     debug(
       'copying file from %s:%s to %s:%s',
       this.options.bucket,
       source,
-      this.options.bucket,
+      targetBucket,
       destination
     )
-
-    options = options || {}
 
     /**
      * Copy visibility from the source file to the
      * destination when no inline visibility is
      * defined
      */
-    if (!options.visibility && this.#supportsACL) {
-      options.visibility = await this.getVisibility(source)
+    if (!writeOptions.visibility && this.#supportsACL) {
+      writeOptions.visibility = await this.getVisibility(source)
     }
 
     await this.#client.send(
       this.createCopyObjectCommand(this.#client, {
-        ...this.#getSaveOptions(destination, options),
+        ...this.#getSaveOptions(destination, writeOptions),
         Key: destination,
         CopySource: `/${this.options.bucket}/${source}`,
-        Bucket: this.options.bucket,
+        Bucket: targetBucket,
       })
     )
   }
@@ -617,15 +621,13 @@ export class S3Driver implements DriverContract {
   /**
    * Moves the source file to the destination. Both paths must
    * be within the root location.
+   *
+   * Use the "bucket" option to move the file to a different bucket.
    */
-  async move(source: string, destination: string, options?: WriteOptions): Promise<void> {
-    debug(
-      'moving file from %s:%s to %s:%s',
-      this.options.bucket,
-      source,
-      this.options.bucket,
-      destination
-    )
+  async move(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
+    const targetBucket = options?.bucket || this.options.bucket
+
+    debug('moving file from %s:%s to %s:%s', this.options.bucket, source, targetBucket, destination)
 
     await this.copy(source, destination, options)
     await this.delete(source)

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -22,6 +22,7 @@ import type {
   DriverContract,
   ObjectVisibility,
   SignedURLOptions,
+  CopyMoveOptions,
 } from './types.js'
 
 /**
@@ -169,13 +170,13 @@ export class Disk {
   }
 
   /**
-   * Copies file from the "source" to the "destination" within the
-   * same bucket or the root location of local filesystem.
+   * Copies file from the "source" to the "destination". Use the "bucket"
+   * option to copy the file to a different bucket.
    *
    * Use "copyFromFs" method to copy files from local filesystem to
    * a cloud provider
    */
-  async copy(source: string, destination: string, options?: WriteOptions): Promise<void> {
+  async copy(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
     source = this.#normalizer.normalize(source)
     destination = this.#normalizer.normalize(destination)
     try {
@@ -193,13 +194,13 @@ export class Disk {
   }
 
   /**
-   * Moves file from the "source" to the "destination" within the
-   * same bucket or the root location of local filesystem.
+   * Moves file from the "source" to the "destination". Use the "bucket"
+   * option to move the file to a different bucket.
    *
    * Use "moveFromFs" method to move files from local filesystem to
    * a cloud provider
    */
-  async move(source: string, destination: string, options?: WriteOptions): Promise<void> {
+  async move(source: string, destination: string, options?: CopyMoveOptions): Promise<void> {
     source = this.#normalizer.normalize(source)
     destination = this.#normalizer.normalize(destination)
     try {

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -170,7 +170,7 @@ export class Disk {
   }
 
   /**
-   * Copies file from the "source" to the "destination". Use the "bucket"
+   * Copies file from the "source" to the "destination". Use the "destinationBucket"
    * option to copy the file to a different bucket.
    *
    * Use "copyFromFs" method to copy files from local filesystem to
@@ -194,7 +194,7 @@ export class Disk {
   }
 
   /**
-   * Moves file from the "source" to the "destination". Use the "bucket"
+   * Moves file from the "source" to the "destination". Use the "destinationBucket"
    * option to move the file to a different bucket.
    *
    * Use "moveFromFs" method to move files from local filesystem to

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export type WriteOptions = {
  * Options accepted by the copy and move operations.
  */
 export type CopyMoveOptions = WriteOptions & {
-  bucket?: string
+  destinationBucket?: string
 }
 
 /**
@@ -163,7 +163,7 @@ export interface DriverContract {
    * the "source" and "destination" will be the key names
    * and not absolute paths.
    *
-   * Use the "bucket" option to copy the file to a different bucket.
+   * Use the "destinationBucket" option to copy the file to a different bucket.
    */
   copy(source: string, destination: string, options?: CopyMoveOptions): Promise<void>
 
@@ -172,7 +172,7 @@ export interface DriverContract {
    * the "source" and "destination" will be the key names
    * and not absolute paths.
    *
-   * Use the "bucket" option to move the file to a different bucket.
+   * Use the "destinationBucket" option to move the file to a different bucket.
    */
   move(source: string, destination: string, options?: CopyMoveOptions): Promise<void>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,13 @@ export type WriteOptions = {
 }
 
 /**
+ * Options accepted by the copy and move operations.
+ */
+export type CopyMoveOptions = WriteOptions & {
+  bucket?: string
+}
+
+/**
  * Options accepted during the creation of a signed URL.
  */
 export type SignedURLOptions = {
@@ -155,15 +162,19 @@ export interface DriverContract {
    * Copy the file from within the disk root location. Both
    * the "source" and "destination" will be the key names
    * and not absolute paths.
+   *
+   * Use the "bucket" option to copy the file to a different bucket.
    */
-  copy(source: string, destination: string, options?: WriteOptions): Promise<void>
+  copy(source: string, destination: string, options?: CopyMoveOptions): Promise<void>
 
   /**
    * Move the file from within the disk root location. Both
    * the "source" and "destination" will be the key names
    * and not absolute paths.
+   *
+   * Use the "bucket" option to move the file to a different bucket.
    */
-  move(source: string, destination: string, options?: WriteOptions): Promise<void>
+  move(source: string, destination: string, options?: CopyMoveOptions): Promise<void>
 
   /**
    * Delete the file for the given key. Should not throw

--- a/tests/drivers/gcs/copy.spec.ts
+++ b/tests/drivers/gcs/copy.spec.ts
@@ -109,4 +109,23 @@ test.group('GCS Driver | copy', (group) => {
     const existsResponse = await noUniformedAclBucket.file(source).exists()
     assert.isTrue(existsResponse[0])
   })
+
+  test('copy file with explicit bucket option', async ({ assert }) => {
+    const source = `${string.random(6)}.txt`
+    const destination = `${string.random(6)}.txt`
+    const contents = 'Hello world'
+
+    const fdgcs = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+    await fdgcs.put(source, contents)
+    await fdgcs.copy(source, destination, { bucket: GCS_BUCKET })
+
+    assert.equal(await fdgcs.get(destination), contents)
+    const [exists] = await bucket.file(source).exists()
+    assert.isTrue(exists)
+  })
 })

--- a/tests/drivers/gcs/copy.spec.ts
+++ b/tests/drivers/gcs/copy.spec.ts
@@ -122,7 +122,7 @@ test.group('GCS Driver | copy', (group) => {
       usingUniformAcl: true,
     })
     await fdgcs.put(source, contents)
-    await fdgcs.copy(source, destination, { bucket: GCS_BUCKET })
+    await fdgcs.copy(source, destination, { destinationBucket: GCS_BUCKET })
 
     assert.equal(await fdgcs.get(destination), contents)
     const [exists] = await bucket.file(source).exists()

--- a/tests/drivers/gcs/copy.spec.ts
+++ b/tests/drivers/gcs/copy.spec.ts
@@ -11,7 +11,7 @@ import { test } from '@japa/runner'
 import string from '@poppinss/utils/string'
 import { Storage } from '@google-cloud/storage'
 import { GCSDriver } from '../../../drivers/gcs/driver.js'
-import { GCS_BUCKET, GCS_FINE_GRAINED_ACL_BUCKET, GCS_KEY } from './env.js'
+import { GCS_BUCKET, GCS_FINE_GRAINED_ACL_BUCKET, GCS_KEY, GCS_OTHER_BUCKET } from './env.js'
 
 /**
  * Direct access to Google cloud storage bucket
@@ -20,6 +20,9 @@ import { GCS_BUCKET, GCS_FINE_GRAINED_ACL_BUCKET, GCS_KEY } from './env.js'
 const bucket = new Storage({
   credentials: GCS_KEY,
 }).bucket(GCS_BUCKET)
+const otherBucket = new Storage({
+  credentials: GCS_KEY,
+}).bucket(GCS_OTHER_BUCKET)
 const noUniformedAclBucket = new Storage({
   credentials: GCS_KEY,
 }).bucket(GCS_FINE_GRAINED_ACL_BUCKET)
@@ -28,6 +31,7 @@ test.group('GCS Driver | copy', (group) => {
   group.each.setup(() => {
     return async () => {
       await bucket.deleteFiles()
+      await otherBucket.deleteFiles()
       await noUniformedAclBucket.deleteFiles()
     }
   })
@@ -127,5 +131,35 @@ test.group('GCS Driver | copy', (group) => {
     assert.equal(await fdgcs.get(destination), contents)
     const [exists] = await bucket.file(source).exists()
     assert.isTrue(exists)
+  })
+
+  test('copy file to another bucket with explicit bucket option', async ({ assert }) => {
+    const source = `${string.random(6)}.txt`
+    const destination = `${string.random(6)}.txt`
+    const contents = 'Hello world'
+
+    const sourceDriver = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+    const destinationDriver = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_OTHER_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+
+    await sourceDriver.put(source, contents)
+    await sourceDriver.copy(source, destination, { destinationBucket: GCS_OTHER_BUCKET })
+
+    assert.equal(await destinationDriver.get(destination), contents)
+
+    const [sourceExists] = await bucket.file(source).exists()
+    const [destinationExists] = await otherBucket.file(destination).exists()
+
+    assert.isTrue(sourceExists)
+    assert.isTrue(destinationExists)
   })
 })

--- a/tests/drivers/gcs/env.ts
+++ b/tests/drivers/gcs/env.ts
@@ -12,9 +12,11 @@ import { Env } from '@adonisjs/env'
 const env = await Env.create(new URL('../../../', import.meta.url), {
   GCS_KEY: Env.schema.string(),
   GCS_BUCKET: Env.schema.string(),
+  GCS_OTHER_BUCKET: Env.schema.string(),
   GCS_FINE_GRAINED_ACL_BUCKET: Env.schema.string(),
 })
 
 export const GCS_BUCKET = env.get('GCS_BUCKET')
+export const GCS_OTHER_BUCKET = env.get('GCS_OTHER_BUCKET')
 export const GCS_KEY = JSON.parse(env.get('GCS_KEY'))
 export const GCS_FINE_GRAINED_ACL_BUCKET = env.get('GCS_FINE_GRAINED_ACL_BUCKET')

--- a/tests/drivers/gcs/move.spec.ts
+++ b/tests/drivers/gcs/move.spec.ts
@@ -114,4 +114,23 @@ test.group('GCS Driver | move', (group) => {
     const existsResponse = await noUniformedAclBucket.file(source).exists()
     assert.isFalse(existsResponse[0])
   })
+
+  test('move file with explicit bucket option', async ({ assert }) => {
+    const source = `${string.random(10)}.txt`
+    const destination = `${string.random(10)}.txt`
+    const contents = 'Hello world'
+
+    const fdgcs = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+    await fdgcs.put(source, contents)
+    await fdgcs.move(source, destination, { bucket: GCS_BUCKET })
+
+    assert.equal(await fdgcs.get(destination), contents)
+    const [exists] = await bucket.file(source).exists()
+    assert.isFalse(exists)
+  })
 })

--- a/tests/drivers/gcs/move.spec.ts
+++ b/tests/drivers/gcs/move.spec.ts
@@ -127,7 +127,7 @@ test.group('GCS Driver | move', (group) => {
       usingUniformAcl: true,
     })
     await fdgcs.put(source, contents)
-    await fdgcs.move(source, destination, { bucket: GCS_BUCKET })
+    await fdgcs.move(source, destination, { destinationBucket: GCS_BUCKET })
 
     assert.equal(await fdgcs.get(destination), contents)
     const [exists] = await bucket.file(source).exists()

--- a/tests/drivers/gcs/move.spec.ts
+++ b/tests/drivers/gcs/move.spec.ts
@@ -10,7 +10,7 @@
 import { test } from '@japa/runner'
 import string from '@poppinss/utils/string'
 import { Storage } from '@google-cloud/storage'
-import { GCS_BUCKET, GCS_FINE_GRAINED_ACL_BUCKET, GCS_KEY } from './env.js'
+import { GCS_BUCKET, GCS_FINE_GRAINED_ACL_BUCKET, GCS_KEY, GCS_OTHER_BUCKET } from './env.js'
 import { GCSDriver } from '../../../drivers/gcs/driver.js'
 
 /**
@@ -20,6 +20,9 @@ import { GCSDriver } from '../../../drivers/gcs/driver.js'
 const bucket = new Storage({
   credentials: GCS_KEY,
 }).bucket(GCS_BUCKET)
+const otherBucket = new Storage({
+  credentials: GCS_KEY,
+}).bucket(GCS_OTHER_BUCKET)
 const noUniformedAclBucket = new Storage({
   credentials: GCS_KEY,
 }).bucket(GCS_FINE_GRAINED_ACL_BUCKET)
@@ -28,6 +31,7 @@ test.group('GCS Driver | move', (group) => {
   group.each.setup(() => {
     return async () => {
       await bucket.deleteFiles()
+      await otherBucket.deleteFiles()
       await noUniformedAclBucket.deleteFiles()
     }
   })
@@ -132,5 +136,35 @@ test.group('GCS Driver | move', (group) => {
     assert.equal(await fdgcs.get(destination), contents)
     const [exists] = await bucket.file(source).exists()
     assert.isFalse(exists)
+  })
+
+  test('move file to another bucket with explicit bucket option', async ({ assert }) => {
+    const source = `${string.random(10)}.txt`
+    const destination = `${string.random(10)}.txt`
+    const contents = 'Hello world'
+
+    const sourceDriver = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+    const destinationDriver = new GCSDriver({
+      visibility: 'public',
+      bucket: GCS_OTHER_BUCKET,
+      credentials: GCS_KEY,
+      usingUniformAcl: true,
+    })
+
+    await sourceDriver.put(source, contents)
+    await sourceDriver.move(source, destination, { destinationBucket: GCS_OTHER_BUCKET })
+
+    assert.equal(await destinationDriver.get(destination), contents)
+
+    const [sourceExists] = await bucket.file(source).exists()
+    const [destinationExists] = await otherBucket.file(destination).exists()
+
+    assert.isFalse(sourceExists)
+    assert.isTrue(destinationExists)
   })
 })

--- a/tests/drivers/s3/copy.spec.ts
+++ b/tests/drivers/s3/copy.spec.ts
@@ -183,5 +183,5 @@ test.group('S3 Driver | copy', (group) => {
     assert.isDefined(capturedOptions)
     assert.equal(capturedOptions!.Bucket, S3_OTHER_BUCKET)
     assert.equal(capturedOptions!.CopySource, `/${S3_BUCKET}/${source}`)
-  }).pin()
+  })
 })

--- a/tests/drivers/s3/copy.spec.ts
+++ b/tests/drivers/s3/copy.spec.ts
@@ -149,7 +149,7 @@ test.group('S3 Driver | copy', (group) => {
       supportsACL: SUPPORTS_ACL,
     })
     await s3fs.put(source, contents)
-    await s3fs.copy(source, destination, { bucket: S3_BUCKET })
+    await s3fs.copy(source, destination, { destinationBucket: S3_BUCKET })
 
     assert.equal(await s3fs.get(destination), contents)
     assert.isTrue(await s3fs.exists(source))
@@ -177,10 +177,10 @@ test.group('S3 Driver | copy', (group) => {
     })
 
     await s3fs.put(source, contents)
-    await s3fs.copy(source, destination, { bucket: 'other-bucket' }).catch(() => {})
+    await s3fs.copy(source, destination, { destinationBucket: 'flydrive-other-bucket' })
 
     assert.isDefined(capturedOptions)
-    assert.equal(capturedOptions!.Bucket, 'other-bucket')
+    assert.equal(capturedOptions!.Bucket, 'flydrive-other-bucket')
     assert.equal(capturedOptions!.CopySource, `/${S3_BUCKET}/${source}`)
   })
 })

--- a/tests/drivers/s3/copy.spec.ts
+++ b/tests/drivers/s3/copy.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from '@japa/runner'
 import string from '@poppinss/utils/string'
-import { S3Client } from '@aws-sdk/client-s3'
+import { S3Client, type CopyObjectCommandInput } from '@aws-sdk/client-s3'
 
 import { S3Driver } from '../../../drivers/s3/driver.js'
 import {
@@ -136,4 +136,51 @@ test.group('S3 Driver | copy', (group) => {
 
     assert.isTrue(await s3fs.exists(source))
   }).skip(!SUPPORTS_ACL, 'Service does not support ACL. Hence, we cannot control file visibility')
+
+  test('copy file with explicit bucket option', async ({ assert }) => {
+    const source = `${string.random(6)}.txt`
+    const destination = `${string.random(6)}.txt`
+    const contents = 'Hello world'
+
+    const s3fs = new S3Driver({
+      visibility: 'public',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+    })
+    await s3fs.put(source, contents)
+    await s3fs.copy(source, destination, { bucket: S3_BUCKET })
+
+    assert.equal(await s3fs.get(destination), contents)
+    assert.isTrue(await s3fs.exists(source))
+  })
+
+  test('copy command receives the correct destination bucket', async ({ assert }) => {
+    let capturedOptions: CopyObjectCommandInput | undefined
+
+    class TestS3Driver extends S3Driver {
+      protected createCopyObjectCommand(_client: S3Client, options: CopyObjectCommandInput) {
+        capturedOptions = options
+        return super.createCopyObjectCommand(_client, options)
+      }
+    }
+
+    const source = `${string.random(6)}.txt`
+    const destination = `${string.random(6)}.txt`
+    const contents = 'Hello world'
+
+    const s3fs = new TestS3Driver({
+      visibility: 'public',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+    })
+
+    await s3fs.put(source, contents)
+    await s3fs.copy(source, destination, { bucket: 'other-bucket' }).catch(() => {})
+
+    assert.isDefined(capturedOptions)
+    assert.equal(capturedOptions!.Bucket, 'other-bucket')
+    assert.equal(capturedOptions!.CopySource, `/${S3_BUCKET}/${source}`)
+  })
 })

--- a/tests/drivers/s3/copy.spec.ts
+++ b/tests/drivers/s3/copy.spec.ts
@@ -16,9 +16,10 @@ import {
   S3_REGION,
   S3_BUCKET,
   S3_ENDPOINT,
+  SUPPORTS_ACL,
   AWS_ACCESS_KEY,
   AWS_ACCESS_SECRET,
-  SUPPORTS_ACL,
+  S3_OTHER_BUCKET,
 } from './env.js'
 import { deleteS3Objects } from '../../helpers.js'
 
@@ -177,10 +178,10 @@ test.group('S3 Driver | copy', (group) => {
     })
 
     await s3fs.put(source, contents)
-    await s3fs.copy(source, destination, { destinationBucket: 'flydrive-other-bucket' })
+    await s3fs.copy(source, destination, { destinationBucket: S3_OTHER_BUCKET })
 
     assert.isDefined(capturedOptions)
-    assert.equal(capturedOptions!.Bucket, 'flydrive-other-bucket')
+    assert.equal(capturedOptions!.Bucket, S3_OTHER_BUCKET)
     assert.equal(capturedOptions!.CopySource, `/${S3_BUCKET}/${source}`)
-  })
+  }).pin()
 })

--- a/tests/drivers/s3/env.ts
+++ b/tests/drivers/s3/env.ts
@@ -12,6 +12,7 @@ import { Env } from '@adonisjs/env'
 const env = await Env.create(new URL('../../../', import.meta.url), {
   S3_SERVICE: Env.schema.enum(['r2', 'do'] as const),
   S3_BUCKET: Env.schema.string(),
+  S3_OTHER_BUCKET: Env.schema.string(),
   S3_ACCESS_KEY: Env.schema.string(),
   S3_ACCESS_SECRET: Env.schema.string(),
   S3_ENDPOINT: Env.schema.string(),
@@ -22,6 +23,7 @@ const env = await Env.create(new URL('../../../', import.meta.url), {
 export const S3_SERVICE = env.get('S3_SERVICE')
 export const SUPPORTS_ACL = S3_SERVICE !== 'r2'
 export const S3_BUCKET = env.get('S3_BUCKET')
+export const S3_OTHER_BUCKET = env.get('S3_OTHER_BUCKET')
 export const S3_CDN_URL = env.get('S3_CDN_URL')
 export const S3_REGION = env.get('S3_REGION')
 export const S3_ENDPOINT = env.get('S3_ENDPOINT')

--- a/tests/drivers/s3/move.spec.ts
+++ b/tests/drivers/s3/move.spec.ts
@@ -151,7 +151,7 @@ test.group('S3 Driver | move', (group) => {
       supportsACL: SUPPORTS_ACL,
     })
     await s3fs.put(source, contents)
-    await s3fs.move(source, destination, { bucket: S3_BUCKET })
+    await s3fs.move(source, destination, { destinationBucket: S3_BUCKET })
 
     assert.equal(await s3fs.get(destination), contents)
     assert.isFalse(await s3fs.exists(source))
@@ -179,10 +179,10 @@ test.group('S3 Driver | move', (group) => {
     })
 
     await s3fs.put(source, contents)
-    await s3fs.move(source, destination, { bucket: 'other-bucket' }).catch(() => {})
+    await s3fs.move(source, destination, { destinationBucket: 'flydrive-other-bucket' })
 
     assert.isDefined(capturedOptions)
-    assert.equal(capturedOptions!.Bucket, 'other-bucket')
+    assert.equal(capturedOptions!.Bucket, 'flydrive-other-bucket')
     assert.equal(capturedOptions!.CopySource, `/${S3_BUCKET}/${source}`)
   })
 })

--- a/tests/drivers/s3/move.spec.ts
+++ b/tests/drivers/s3/move.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from '@japa/runner'
 import string from '@poppinss/utils/string'
-import { S3Client } from '@aws-sdk/client-s3'
+import { S3Client, type CopyObjectCommandInput } from '@aws-sdk/client-s3'
 
 import { S3Driver } from '../../../drivers/s3/driver.js'
 import {
@@ -138,4 +138,51 @@ test.group('S3 Driver | move', (group) => {
     assert.equal(visibility, 'private')
     assert.isFalse(await s3fs.exists(source))
   }).skip(!SUPPORTS_ACL, 'Service does not support ACL. Hence, we cannot control file visibility')
+
+  test('move file with explicit bucket option', async ({ assert }) => {
+    const source = `${string.random(10)}.txt`
+    const destination = `${string.random(10)}.txt`
+    const contents = 'Hello world'
+
+    const s3fs = new S3Driver({
+      visibility: 'public',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+    })
+    await s3fs.put(source, contents)
+    await s3fs.move(source, destination, { bucket: S3_BUCKET })
+
+    assert.equal(await s3fs.get(destination), contents)
+    assert.isFalse(await s3fs.exists(source))
+  })
+
+  test('move command receives the correct destination bucket', async ({ assert }) => {
+    let capturedOptions: CopyObjectCommandInput | undefined
+
+    class TestS3Driver extends S3Driver {
+      protected createCopyObjectCommand(_client: S3Client, options: CopyObjectCommandInput) {
+        capturedOptions = options
+        return super.createCopyObjectCommand(_client, options)
+      }
+    }
+
+    const source = `${string.random(10)}.txt`
+    const destination = `${string.random(10)}.txt`
+    const contents = 'Hello world'
+
+    const s3fs = new TestS3Driver({
+      visibility: 'public',
+      client: client,
+      bucket: S3_BUCKET,
+      supportsACL: SUPPORTS_ACL,
+    })
+
+    await s3fs.put(source, contents)
+    await s3fs.move(source, destination, { bucket: 'other-bucket' }).catch(() => {})
+
+    assert.isDefined(capturedOptions)
+    assert.equal(capturedOptions!.Bucket, 'other-bucket')
+    assert.equal(capturedOptions!.CopySource, `/${S3_BUCKET}/${source}`)
+  })
 })

--- a/tests/drivers/s3/move.spec.ts
+++ b/tests/drivers/s3/move.spec.ts
@@ -19,6 +19,7 @@ import {
   AWS_ACCESS_KEY,
   AWS_ACCESS_SECRET,
   SUPPORTS_ACL,
+  S3_OTHER_BUCKET,
 } from './env.js'
 import { deleteS3Objects } from '../../helpers.js'
 
@@ -179,10 +180,10 @@ test.group('S3 Driver | move', (group) => {
     })
 
     await s3fs.put(source, contents)
-    await s3fs.move(source, destination, { destinationBucket: 'flydrive-other-bucket' })
+    await s3fs.move(source, destination, { destinationBucket: S3_OTHER_BUCKET })
 
     assert.isDefined(capturedOptions)
-    assert.equal(capturedOptions!.Bucket, 'flydrive-other-bucket')
+    assert.equal(capturedOptions!.Bucket, S3_OTHER_BUCKET)
     assert.equal(capturedOptions!.CopySource, `/${S3_BUCKET}/${source}`)
   })
 })


### PR DESCRIPTION
Hey! 👋🏻 

This PR allows `copy` and `move` operations to target a different bucket instead of always operating within the same one. A new `CopyMoveOptions` type extends `WriteOptions` with an optional bucket property, so users can write:

```ts
disk.copy(src, dest, { bucket: 'other-bucket' })
```

Both the S3 and GCS drivers have been updated to use this destination bucket for the target while keeping the current bucket as the source. The change is fully backward compatible since omitting bucket behaves exactly as before.

Integration tests have been added for both S3 and GCS that pass the bucket option explicitly with the same bucket to validate the code path.

For S3 specifically, unit tests subclass the driver to verify that `CopyObjectCommand` receives the correct `Bucket` and `CopySource` values when a different destination bucket is provided.

**True cross-bucket integration tests with a second real bucket are not included as they would require additional CI configuration.**